### PR TITLE
Issue #2: Smaller queries for list and chart fixes

### DIFF
--- a/src/app/courses/course-chart/course-chart.component.html
+++ b/src/app/courses/course-chart/course-chart.component.html
@@ -7,10 +7,9 @@
         <input
           matInput
           [formControl]="deptControl"
-          (ngModelChange)="onDepartmentChange($event.value)"
           [matAutocomplete]="auto"
         />
-        <mat-autocomplete #auto="matAutocomplete">
+        <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onDepartmentChange($event.option.value)">
           <mat-option *ngFor="let option of filteredDeptOptions | async" [value]="option.value">
             {{ option.view }}
           </mat-option>

--- a/src/app/courses/course-chart/course-chart.component.ts
+++ b/src/app/courses/course-chart/course-chart.component.ts
@@ -53,8 +53,33 @@ export class CourseChartComponent implements OnInit, AfterViewInit {
   public departmentOptions: any[] = [''].concat(courseCategories); // Example department codes
   public courseLevelOptions: any[] = ['',100, 200, 300, 400, 500, 600]; // Example course levels
 
-  public onDepartmentChange(department: string): void {
+  public async onDepartmentChange(department: string): Promise<void> {
     this.selectedDepartment = department;
+    await this.courses.getClassesByDepartment(this.deptControl.value || '');
+    this.courses.classes.subscribe((data) => {
+      const processedData = data.map((x) => {
+        x.season_str = [];
+        if (x.season.fall) x.season_str.push('fall');
+        if (x.season.spring) x.season_str.push('spring');
+        if (x.season.summer) x.season_str.push('summer');
+        return x;
+      });
+      this.classes = processedData;
+
+      this.courseData = data.map(classData => ({
+        label: classData.CourseNumber,
+        data: [{
+          x: classData.DifficultyAvg,
+          y: classData.RatingAvg,
+          r: classData.RatingCount,
+        }],
+        backgroundColor: randomColor(),
+        classData: classData,
+      }));
+
+      //this.applyFilters();  // Apply filters initially if needed
+      this.dataSource.sort = this.sort;
+    });
     this.applyFilters();
   }
   
@@ -105,6 +130,7 @@ export class CourseChartComponent implements OnInit, AfterViewInit {
   }
 
   public ngAfterViewInit(): void {
+    this.courses.getClassesByDepartment(this.deptControl.value || '');
     this.courses.classes.subscribe((data) => {
       const processedData = data.map((x) => {
         x.season_str = [];
@@ -126,7 +152,7 @@ export class CourseChartComponent implements OnInit, AfterViewInit {
         classData: classData,
       }));
 
-      this.applyFilters();  // Apply filters initially if needed
+      //this.applyFilters();  // Apply filters initially if needed
       this.dataSource.sort = this.sort;
     });
   }

--- a/src/app/courses/course-chart/course-chart.component.ts
+++ b/src/app/courses/course-chart/course-chart.component.ts
@@ -116,7 +116,6 @@ export class CourseChartComponent implements OnInit, AfterViewInit {
     }
   
     // Update the chart with filtered data
-    //console.log('Filtered data:', filteredData);
     this.redrawChart(filteredData);
     // Update dataSource with filtered data
     this.dataSource.data = filteredData;

--- a/src/app/courses/course-detail/course-detail.component.ts
+++ b/src/app/courses/course-detail/course-detail.component.ts
@@ -59,6 +59,7 @@ export class CourseDetailComponent implements OnInit, AfterViewInit {
 
     ngAfterViewInit(): void {
         if (!this.course) {
+            this.repopulateDepartment();
             this.getClassData();
         }
     }
@@ -370,15 +371,21 @@ export class CourseDetailComponent implements OnInit, AfterViewInit {
             this.courseName = param.substring(pos + 1).replace(/-/g, ' ')
         }
         this.auth.isLoggedIn.subscribe(state => { this.isLoggedIn = state });
+        this.repopulateDepartment();
         this.getClassData();
         this.getFirstPage();
         document.getElementsByClassName("mat-drawer-content")[0].scroll(0, 0);
     }
 
+    async repopulateDepartment(): Promise<void> {
+        await this.classService.getClassesByDepartment(this.course?.Department || "");
+    }
+
     getClassData(): void {
+        console.log("Getting class data", this.classService.classes);
         this.classService.classes.subscribe(data => {
             this.course = data.find(x => x.ClassName == this.courseName);
-            
+            console.log("data", data, this.course);
             if (!this.course) {
                 this.router.navigate(['404']);
             } else {

--- a/src/app/courses/course-detail/course-detail.component.ts
+++ b/src/app/courses/course-detail/course-detail.component.ts
@@ -382,10 +382,8 @@ export class CourseDetailComponent implements OnInit, AfterViewInit {
     }
 
     getClassData(): void {
-        console.log("Getting class data", this.classService.classes);
         this.classService.classes.subscribe(data => {
             this.course = data.find(x => x.ClassName == this.courseName);
-            console.log("data", data, this.course);
             if (!this.course) {
                 this.router.navigate(['404']);
             } else {

--- a/src/app/courses/course-edit/course-edit.component.ts
+++ b/src/app/courses/course-edit/course-edit.component.ts
@@ -35,6 +35,7 @@ export class EditCourseComponent implements OnInit {
             seasonFall: [false, Validators.required],
             languages: [''],
         })
+        this.courseService.getClassesByDepartment(this.courseData?.Department as string)
         this.courseService.classes.subscribe(data => {
             this.courseData = data.find(x => x.ClassName == this.courseName)
             this.f.departments.setValue(this.courseData?.Department)

--- a/src/app/courses/course-list/course-list.component.html
+++ b/src/app/courses/course-list/course-list.component.html
@@ -13,10 +13,9 @@
           <input
             matInput
             [formControl]="deptControl"
-            (ngModelChange)="onDeptFilterChange($event)"
             [matAutocomplete]="auto"
           />
-          <mat-autocomplete #auto="matAutocomplete">
+          <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onDeptFilterChange($event.option.value)">
             <mat-option *ngFor="let option of filteredDeptOptions | async" [value]="option.value">
               {{ option.view }}
             </mat-option>

--- a/src/app/courses/course-list/course-list.component.ts
+++ b/src/app/courses/course-list/course-list.component.ts
@@ -85,7 +85,6 @@ export class CourseListComponent implements AfterViewInit, OnInit {
         return x;
       });
       this.classes = processedData;
-      //this.applyFilters();  // Apply filters initially if needed
       this.dataSource.sort = this.sort;
     });
   }
@@ -107,7 +106,6 @@ export class CourseListComponent implements AfterViewInit, OnInit {
     }
   
     let filteredData = this.classes;
-    console.log('Filtered data:', filteredData);
   
     // Apply department filter
     if (this.deptControl.value) {

--- a/src/app/courses/course-list/course-list.component.ts
+++ b/src/app/courses/course-list/course-list.component.ts
@@ -75,6 +75,7 @@ export class CourseListComponent implements AfterViewInit, OnInit {
   }
 
   ngAfterViewInit(): void {
+    this.courses.getClassesByDepartment(this.deptControl.value || '');
     this.courses.classes.subscribe((data) => {
       const processedData = data.map((x) => {
         x.season_str = [];
@@ -84,7 +85,7 @@ export class CourseListComponent implements AfterViewInit, OnInit {
         return x;
       });
       this.classes = processedData;
-      this.applyFilters();  // Apply filters initially if needed
+      //this.applyFilters();  // Apply filters initially if needed
       this.dataSource.sort = this.sort;
     });
   }
@@ -106,6 +107,7 @@ export class CourseListComponent implements AfterViewInit, OnInit {
     }
   
     let filteredData = this.classes;
+    console.log('Filtered data:', filteredData);
   
     // Apply department filter
     if (this.deptControl.value) {
@@ -156,7 +158,19 @@ export class CourseListComponent implements AfterViewInit, OnInit {
     this.dataSource.data = filteredData;
   }
 
-  onDeptFilterChange(value: string): void {
+  async onDeptFilterChange(value: string): Promise<void> {
+    await this.courses.getClassesByDepartment(this.deptControl.value || '');
+    this.courses.classes.subscribe((data) => {
+      const processedData = data.map((x) => {
+        x.season_str = [];
+        if (x.season.fall) x.season_str.push('fall');
+        if (x.season.spring) x.season_str.push('spring');
+        if (x.season.summer) x.season_str.push('summer');
+        return x;
+      });
+      this.classes = processedData;
+      this.dataSource.sort = this.sort;
+    });
     this.applyFilters();
   }
 

--- a/src/app/reviews/review-detail/review-detail.component.ts
+++ b/src/app/reviews/review-detail/review-detail.component.ts
@@ -68,6 +68,7 @@ export class ReviewDetailComponent implements OnInit {
         rev.reviewId = docSnap.id
 
         var courses: ClassData[] = []
+        this.classService.getClassesByDepartment(rev.Department)
         this.classService.classes.subscribe(data => { courses = data })
         const course = courses.find(item => item.courseId == rev.classId)
 

--- a/src/app/reviews/reviews.component.ts
+++ b/src/app/reviews/reviews.component.ts
@@ -52,6 +52,7 @@ export class ReviewsComponent implements OnInit {
 
     ngOnInit(): void {
         this.auth.isLoggedIn.subscribe(state => { this.isLoggedIn = state })
+        this.classService.getClassesByDepartment(this.selectedDepartment)
         this.classService.classes.subscribe(data => { this.courses = data })
         this.filteredDeptOptions = this.deptControl.valueChanges.pipe(
             startWith(''),

--- a/src/app/services/classes/class.service.ts
+++ b/src/app/services/classes/class.service.ts
@@ -22,7 +22,7 @@ export class ClassService {
             data.courseId = doc.id;
             return data;
         });
-        this._classes = new ReplaySubject(); // Clear the ReplaySubject buffer
+        this._classes = new ReplaySubject(); // TODO: figure out a better way to do this or if this is going to increase # of reads
         this._classes.next(classes) 
         this.classes = this._classes.asObservable();
     }

--- a/src/app/services/classes/class.service.ts
+++ b/src/app/services/classes/class.service.ts
@@ -12,17 +12,19 @@ export class ClassService {
 
     constructor(
         private afs: Firestore,
-    ) {
+    ) {}
+    async getClassesByDepartment(department: string){
         const ref = collection(this.afs, 'Class')
-        const unsubscribe = onSnapshot(ref, (querySnapshot) => {
-            const classes: ClassData[] = [];
-            querySnapshot.forEach((doc) => {
-                var data = doc.data()
-                data['courseId'] = doc.id
-                classes.push(data as ClassData);
-            });
-            this._classes.next(classes)
+        const q = query(ref, where('Department', '==', department));
+        const querySnapshot = await getDocs(q);
+        const classes: ClassData[] = querySnapshot.docs.map((doc) => {
+            const data = doc.data() as ClassData;
+            data.courseId = doc.id;
+            return data;
         });
+        this._classes = new ReplaySubject(); // Clear the ReplaySubject buffer
+        this._classes.next(classes) 
+        this.classes = this._classes.asObservable();
     }
     async getCoursesByDepartment(department: string): Promise<ClassData[]> {
         const ref = collection(this.afs, 'Class');


### PR DESCRIPTION
We now will not read 11k documents from Firebase every time someone opens to app. It should be much much less. There might be some better ways to optimize it (since I get rid of the ReplaySubject each time getClassesByDepartment is called), but the tradeoff should 100% be worth it right now. 

Closes #2 